### PR TITLE
Don't die silently when started by non-root user

### DIFF
--- a/src/daemonizer.py
+++ b/src/daemonizer.py
@@ -75,9 +75,13 @@ class Daemon(object):
         pid = str(os.getpid())
         file(self._pidfile,'w+').write("%s\n" % pid)
         if os.path.exists('/var/lock/subsys'):
-            fh = open(os.path.join('/var/lock/subsys', self._serviceName), 'w')
-            fh.close()
-    
+            try:
+                fh = open(os.path.join('/var/lock/subsys', self._serviceName), 'w')
+                fh.close()
+            except IOError as e:
+                if e.errno == 13:
+                    pass
+
     def _delpid(self):
         if os.path.exists(self._pidfile):
             os.remove(self._pidfile)


### PR DESCRIPTION
For CentOS 7 the /var/lock/subsys directory is writeable only by root, so the modified call to 'open' will throw an exception unless the process has been invoked by root.